### PR TITLE
Fixing incorrect variable usage

### DIFF
--- a/1-js/05-data-types/06-iterable/article.md
+++ b/1-js/05-data-types/06-iterable/article.md
@@ -180,7 +180,7 @@ let diziBenzeri = { //  indekslere ve uzunluğa sahiptir => dizi-benzeri
 
 *!*
 // Hata Symbol.iterator bulunmamaktadır.
-for(let item of arrayLike) {}
+for(let item of diziBenzeri) {}
 */!*
 ```
 


### PR DESCRIPTION
There is an error in using variable name in line 183.

```js
let diziBenzeri = { 
  0: "Merhaba",
  1: "Dünya",
  length: 2
};

for(let item of arrayLike) {} // must be: for(let item of diziBenzeri) {}
```