### PR TITLE
Fixing incorrect variable usage

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -466,7 +466,7 @@ alert( str.split('') ); // t,e,s,t
 ```js run
 let dizi = ['Bilbo', 'Gandalf', 'Nazgul'];
 
-let str = arr.join(';');
+let str = dizi.join(';');
 
 alert( str ); // Bilbo;Gandalf;Nazgul
 ```


### PR DESCRIPTION
An incorrect variable name was used. Since it was a minor mistake, I immediately corrected it. Wrong use:

```js
let dizi = ['Bilbo', 'Gandalf', 'Nazgul'];

let str = srt.join(';'); // must be: let str = dizi.join(';');

alert( str );
```