### PR TITLE
Incorrect function name usage

### DIFF
--- a/1-js/06-advanced-functions/01-recursion/article.md
+++ b/1-js/06-advanced-functions/01-recursion/article.md
@@ -87,7 +87,7 @@ Aşağıda aynı fonksiyonun `?` ile tekrar yazılmış hali bulunmaktadır.
 
 ```js run
 function us(x, n) {
-  return (n == 1) ? x : (x * pow(x, n-1));
+  return (n == 1) ? x : (x * us(x, n-1));
 }
 ```
 ````


### PR DESCRIPTION
```js run
function us(x, n) {
  return (n == 1) ? x : (x * pow(x, n-1)); // must be: return (n == 1) ? x : (x * us(x, n-1));
}
```