### PR TITLE
first-steps typo fixes

### DIFF
--- a/1-js/02-first-steps/10-ifelse/article.md
+++ b/1-js/02-first-steps/10-ifelse/article.md
@@ -3,7 +3,7 @@
 
 Bazı durumlarda koşula göre farklı eylemler yapmak isteyebilirsiniz.
 
-`"?"` operatörü veya `if` cümlesi bu koşulları kontrol etmenizi sağlar. 
+`"?"` operatörü veya `if` cümlesi bu koşulları kontrol etmenizi sağlar.
 
 ## "if" cümlesi
 
@@ -64,7 +64,7 @@ if (sonuc) {
 }
 ```
 
-## "else" cümlesi 
+## "else" cümlesi
 
 `if` cümlesi opsiyonel olarak "else" bloğu da içerebilir. Bu eğer `if` parantezi içerisinde yazdığımız kod yanlış ise çalışır.
 
@@ -97,7 +97,7 @@ if (yil < 2015) {
   alert( 'Kesinlikle!' );
 }
 ```
-Yukarıdaki kodda önce `yil < 2015` kontrolü yapılır. Eğer bu değerlendirme yanlış ise bir sonraki koşula geçilir. Eğer `year > 2015` doğru ise bu koşul içindeki alarm fonksiyonu çalışır. Diğer hallerde son `alert` fonksiyonu çalışır. 
+Yukarıdaki kodda önce `yil < 2015` kontrolü yapılır. Eğer bu değerlendirme yanlış ise bir sonraki koşula geçilir. Eğer `year > 2015` doğru ise bu koşul içindeki alarm fonksiyonu çalışır. Diğer hallerde son `alert` fonksiyonu çalışır.
 
 Sonuncusunda bir tane daha `else if` bloğu olabilirdi: `else if ( yil == 2015 )`
 
@@ -210,7 +210,7 @@ let firma = prompt('JavaScript hangi firma tarafından yaratılmıştır?', '');
 */!*
 ```
 
-Koşula göre `firma =='Netscap'`, soru işaretinden sonra birinci bölüm veya ikinci bölüm çalışır.
+Koşula göre `firma =='Netscape'`, soru işaretinden sonra birinci bölüm veya ikinci bölüm çalışır.
 
 Sonucu bir değere atanmamıştır. Amaç duruma göre doğrudan kodu çalıştırmak.
 
@@ -235,4 +235,4 @@ if (firma == 'Netscape') {
 
 Okurken kodu dikey olarak okuruz. Bundan dolayı yazımın bir kaç satıra dağıtılması okumayı uzun satırlara göre daha kolay hale getirir.
 
-`'?'` işaretinin ideal kullanımı sadece o ya da bu sorusudur. Daha uzun bir cümle için `if` kullanmalısınız. 
+`'?'` işaretinin ideal kullanımı sadece o ya da bu sorusudur. Daha uzun bir cümle için `if` kullanmalısınız.

--- a/1-js/02-first-steps/11-logical-operators/article.md
+++ b/1-js/02-first-steps/11-logical-operators/article.md
@@ -100,7 +100,7 @@ Bu klasik "boolean" VEYA tanımını aşarak ilginç kullanımlara neden olmakta
 
 1. **Değişken veya ifadeler dizisinde ilk doğru(true) değeri bulmak için**
 
-    Düşünün bir diziniz var ve içinde `null/undefined` değerler barındırmakta. Siz ilk veriyi bulduğunuzda döndermek istiyorsunuz.
+    Düşünün bir diziniz var ve içinde `null/undefined` değerler barındırmakta. Siz ilk veriyi bulduğunuzda döndürmek istiyorsunuz.
 
     Bunun için `||` kullanabilirsiniz:
 
@@ -114,18 +114,18 @@ Bu klasik "boolean" VEYA tanımını aşarak ilginç kullanımlara neden olmakta
 
     alert( isim ); // "Akif" seçilir – ilk doğru değeri bulduğundan dolayı buradan dönülür ve ekrana "Akif" çıkar.
     ```
-    
+
     Eğer `simdikiKullanici` ve `varsayilanKullanici` yanlış(false) olsaydı `"isimsiz"` yazısı ekrana çıkacaktı.
 
 2. **Kısa devre değerlendirmesi**
-    
+
     Operantlar sadece değer değil ifade de olabilir. VEYA testlerini soldan sağa doğru yapar. Doğru değer bulunduğunda döndürülür. Bu olaya kısa devre değerlendirmesi denir, çünkü soldan sağa en kısa yoldan gitmektedir.
 
     Tabi bunun ifadelere yan etkisi olabilir. Örneğin değer atama
 
     Aşağıdaki örnek çalıştığında `x`'e değer atanmayacak:
 
-    
+
     ```js run no-beautify
     let x;
 
@@ -145,11 +145,11 @@ Bu klasik "boolean" VEYA tanımını aşarak ilginç kullanımlara neden olmakta
     alert(x); // 1
     ```
     Gördüğünüz gibi değer atandı. Böyle basit bir durumda yan etki görmezden gelinebilir.
-    
+
     Kısa yoldan `if` yapısında olduğu gibi ilk operand boolean'a çevrilir ve eğer yanlışsa ikinci değer çalıştırılır.
-    
+
     Çoğu zaman normal `if` yapısını kullanmanız daha iyidir çünkü kod daha anlaşılır olur. Fakat bazen kısa yoldan `if` yapmakta işinize yarayabilir.
-    
+
 
 ## && (AND - VE )
 
@@ -197,8 +197,8 @@ sonuc = deger1 && deger2 && deger3;
 AND `"&&"` operatörü aşağıdaki gibi çalışır:
 
 - Operandları soldan sağa doğru değerlendir.
-- Her bir operandı boolean değere çevir. Eğer sonuç `yanlış` ise dur ve operatörün orijinal değerini dönder.
-- Eğer diğer operandlara erişim sağlandıysa ( hepsinin doğru olma durumu ) sondaki operandı dönder.
+- Her bir operandı boolean değere çevir. Eğer sonuç `yanlış` ise dur ve operatörün orijinal değerini döndür.
+- Eğer diğer operandlara erişim sağlandıysa ( hepsinin doğru olma durumu ) sondaki operandı döndür.
 
 Yukarıdaki kurallar VEYA kuralları ile benzerlik göstermektedir. Farklılık AND operatörünün ilk `yanlış` bulduğunda dönmesi. OR operatörü ise ilk `doğru` bulduğunda dönmekteydi.
 
@@ -278,7 +278,7 @@ result = !value;
 Operatör tek operanddan oluşur ve aşağıdaki şekilde çalışır:
 
 1. Operand değerini boolean tipine çevir: `true/false`
-2. Tersini geri dönder.
+2. Tersini geri döndür.
 
 
 Örneğin:

--- a/1-js/02-first-steps/11-logical-operators/article.md
+++ b/1-js/02-first-steps/11-logical-operators/article.md
@@ -205,7 +205,7 @@ Yukarıdaki kurallar VEYA kuralları ile benzerlik göstermektedir. Farklılık 
 Örnek:
 
 ```js run
-// Eğer ilk opedan doğru ise her halükarda ikincinin değeri dönecek.
+// Eğer ilk operand doğru ise her halükarda ikincinin değeri dönecek.
 alert( 1 && 0 ); // 0
 alert( 1 && 5 ); // 5
 

--- a/1-js/02-first-steps/12-while-for/3-which-value-for/solution.md
+++ b/1-js/02-first-steps/12-while-for/3-which-value-for/solution.md
@@ -1,4 +1,4 @@
-**Cevap: Her iki drum için de `0` dan `4`'e kadardır**
+**Cevap: Her iki durum için de `0` dan `4`'e kadardır**
 
 ```js run
 for (let i = 0; i < 5; ++i) alert( i );

--- a/1-js/02-first-steps/12-while-for/4-for-even/task.md
+++ b/1-js/02-first-steps/12-while-for/4-for-even/task.md
@@ -4,6 +4,6 @@ importance: 5
 
 # Döngüde çift sayıların çıktısını yazdırma
 
-`for` döngüsü kullanarak `2` den `10` a kadar olan çift sayıların çıktısını yazdırıns
+`for` döngüsü kullanarak `2` den `10` a kadar olan çift sayıların çıktısını yazdırın.
 
 [demo]

--- a/1-js/02-first-steps/13-switch/article.md
+++ b/1-js/02-first-steps/13-switch/article.md
@@ -1,7 +1,7 @@
 # "switch" cümleleri
 
 ```
-Türkçe olarak buradaki anlamıyla koşullu ifade demektir.  
+Türkçe olarak buradaki anlamıyla koşullu ifade demektir.
 ```
 
 
@@ -81,7 +81,7 @@ switch (a) {
 */!*
 }
 ```
-Bu döngü çalıştırıldığında ekranda sıralı şekilde uyarılar göreceksiniz. 
+Bu döngü çalıştırıldığında ekranda sıralı şekilde uyarılar göreceksiniz.
 
 ```js
 alert( 'Kesinlikle!' );
@@ -108,13 +108,13 @@ switch (+a) {
     alert("Burası çalışmaz");
 }
 ```
-`+a` `1` değeri dönderir. `case` işleminde `b+1` ile karşılaştırıldığında sonuç `doğru` olduğundan içerideki `alert` çalışır.
+`+a` `1` değeri döndürür. `case` işleminde `b+1` ile karşılaştırıldığında sonuç `doğru` olduğundan içerideki `alert` çalışır.
 ````
 
 ## "case"'leri gruplama
 Gövdesinde aynı kodu çalıştıran birden fazla `case` gruplanabilir.
 
-Örneğin, diyelim ki `case 3` ve `case 5` için aynı kodu çalıştırmak isteniz:
+Örneğin, diyelim ki `case 3` ve `case 5` için aynı kodu çalıştırmak istedik:
 
 ```js run no-beautify
 let a = 2 + 2;
@@ -139,7 +139,7 @@ switch (a) {
 
 `3` ve `5` aynı mesajı gösterecek.
 
-Aslında "gruplama" `switch/case`'in break olmadan çalıştırılmış halidir. 
+Aslında "gruplama" `switch/case`'in break olmadan çalıştırılmış halidir.
 Yan etki de denebilir. `case 3` `(*)`'dan başlar ve arada `break` olmadığından `case 5` ile devam eder.
 
 ## Tipler önemlidir

--- a/1-js/02-first-steps/14-function-basics/1-if-else-required/task.md
+++ b/1-js/02-first-steps/14-function-basics/1-if-else-required/task.md
@@ -4,7 +4,7 @@ importance: 4
 
 # "else" gerekli mi?
 
-Aşağıdaki fonksiyon eğer `yas` parametresi `18`'den büyükse `true` dönderir. 
+Aşağıdaki fonksiyon eğer `yas` parametresi `18`'den büyükse `true` döndürür.
 
 Diğer türlü onay sorar ve sonucunu döndürür.
 

--- a/1-js/02-first-steps/14-function-basics/2-rewrite-function-question-or/task.md
+++ b/1-js/02-first-steps/14-function-basics/2-rewrite-function-question-or/task.md
@@ -4,9 +4,7 @@ importance: 4
 
 # Fonksiyonu '?' veya '||' kullanarak tekrar yazınız.
 
-Aşağıdaki fonksiyon 
-
-Aşağıdaki fonksiyon eğer `yas` parametresi `18`'den büyükse `true` dönderir. 
+Aşağıdaki fonksiyon eğer `yas` parametresi `18`'den büyükse `true` döndürür.
 
 Diğer türlü onay sorar ve sonucunu döndürür.
 
@@ -25,4 +23,4 @@ function yasKontrolu(yas) {
 `yasKontrolu` fonksiyonunun iki türlü versiyonunu yazınız.
 
 1. `'?'` operatörünü kullanarak.
-2. veya kullanarak `||`. 
+2. veya kullanarak `||`.

--- a/1-js/02-first-steps/14-function-basics/article.md
+++ b/1-js/02-first-steps/14-function-basics/article.md
@@ -19,7 +19,7 @@ function mesajGoster() {
 }
 ```
 
-`function` kelimesi önce yazılır, ardından *fonksiyonun adı* ve sonra parametlerin yazılacağı parantez açılır ve ihtiyaç duyulan parametreler yazılır, sonrasında ise kapatılıp süslü parantez ile *fonksiyon gövdesi*ne başlanır.
+`function` kelimesi önce yazılır, ardından *fonksiyonun adı* ve sonra parametrelerin yazılacağı parantez açılır ve ihtiyaç duyulan parametreler yazılır, sonrasında ise kapatılıp süslü parantez ile *fonksiyon gövdesi*ne başlanır.
 
 ![](function_basics.png)
 
@@ -93,11 +93,11 @@ function mesajGoster() {
   alert(mesaj);
 }
 
-alert( kullaniciAdi ); // Fonksiyon çağırılmadan  *!*Adem*/!* 
+alert( kullaniciAdi ); // Fonksiyon çağırılmadan  *!*Adem*/!*
 
 mesajGoster();
 
-alert( kullaniciAdi ); // fonksiyon çağırıldıktan sonra *!*Yusuf*/!*, 
+alert( kullaniciAdi ); // fonksiyon çağırıldıktan sonra *!*Yusuf*/!*,
 ```
 
 Dışarıda bulunan değişkenler eğer yerel değişken yoksa kullanılırlar. Bazen eğer `let` ile değişken oluşturulmazsa karışıklık olabilir.
@@ -333,7 +333,7 @@ Bundan dolayı, tam olarak boş return olur. Geri döndereceğimiz değer ile re
 
 Fonksiyonlar eylemdir. Bundan dolayı isimleri yüklem olmalıdır. Net olmalı ve fonksiyonun ne işe yaradığını ifade edebilmelidir. Böylece kim ki kodu okur, ne yazıldığınına dair bir fikri olur.
 
-Genel itibari ile eylemi tanımlayan önek kullanmak iyi bir yöntemdir. Bu önekler ile ilgili birlikte kod yazdığınız kişiler ile uyum içerisinde olmalısınız. 
+Genel itibari ile eylemi tanımlayan önek kullanmak iyi bir yöntemdir. Bu önekler ile ilgili birlikte kod yazdığınız kişiler ile uyum içerisinde olmalısınız.
 
 Örneğin `"show"` fonksiyonu her zaman bir şeyleri `gösterir`.
 
@@ -373,7 +373,7 @@ Bu örnekler genel olarak öneklerin nasıl tahmin edilmesi gerektiğini göster
 
 ```smart header="Aşırı derecede kısa fonksiyon isimleri"
 
-Çokça kullanılan fonksiyonlar genelde aşırı derece kısa isimlere sahip olurlar. 
+Çokça kullanılan fonksiyonlar genelde aşırı derece kısa isimlere sahip olurlar.
 
 Örneğin, [jQuery](http://jquery.com) kütüphanesi `$` fonksiyonu ile tanımlanır.  [LoDash](http://lodash.com/) kütüphanesi de keza kendine has fonksiyon `_` kullanır.
 

--- a/1-js/02-first-steps/14-function-basics/article.md
+++ b/1-js/02-first-steps/14-function-basics/article.md
@@ -38,7 +38,7 @@ mesajGoster();
 */!*
 ```
 
-`mesajGoster()` fonksiyonu kodu çalıştırır. Bu kod sonrasında `Merhaba millet` uyarsını iki defa göreceksiniz.
+`mesajGoster()` fonksiyonu kodu çalıştırır. Bu kod sonrasında `Merhaba millet` uyarısını iki defa göreceksiniz.
 
 Bu örnek açıkça fonksiyonların ana amacını gösteriyor: Kod tekrarından kaçınma.
 
@@ -128,12 +128,12 @@ Fonksiyonların dışına yazılan her değişken, yukarıda bulunan `kullaniciA
 
 Global değişkenlere her fonksiyon içerisinden erişilebilir.(Yerel değişkenler tarafından aynı isimle bir değişken tanımlanmamışsa)
 
-Genelde fonksiyonlar yapacakları işe ait tüm değişkenleri tanımlarlara, global değişkenler ise sadece proje seviyesinde bilgi tutarlar, çünkü proje seviyesinde bilgilerin projenin her yerinden erişilebilir olması oldukça önemlidir. Modern kodda az veya hiç global değer olmaz. Çoğu fonksiyona ait değişkenlerdir.
+Genelde fonksiyonlar yapacakları işe ait tüm değişkenleri tanımlarlar, global değişkenler ise sadece proje seviyesinde bilgi tutarlar, çünkü proje seviyesinde bilgilerin projenin her yerinden erişilebilir olması oldukça önemlidir. Modern kodda az veya hiç global değer olmaz. Çoğu fonksiyona ait değişkenlerdir.
 
 ```
 
 ## Parametreler
-Paramterelere isteğe bağlı olarak veri paslanabilir. Bunlara *fonksiyon argümanları* da denir.
+Parametrelere isteğe bağlı olarak veri paslanabilir. Bunlara *fonksiyon argümanları* da denir.
 
 Aşağıdaki fonksiyon iki tane parametreye sahiptir. `gonderen` ve `metin`
 
@@ -232,7 +232,7 @@ function mesajGoster(gonderen, metin) {
 ````
 
 
-## Değer dönderme
+## Değer döndürme
 
 Fonksiyon çağırıldığı yere değer döndürebilir.
 
@@ -272,7 +272,7 @@ if ( yasKontrolu(yas) ) {
   alert( 'Reddedildi' );
 }
 ```
-`return` değer döndermek zorunda değildir. Bu fonksiyondan anında çıkmayı sağlar.
+`return` değer döndürmek zorunda değildir. Bu fonksiyondan anında çıkmayı sağlar.
 
 Örneğin:
 
@@ -288,10 +288,10 @@ function filmGoster(age) {
   // ...
 }
 ```
-Yukarıdaki kodda  eğer `yasKontrolu(yas)` `false` dönderir ise  `filmGoster` fonksiyonu `alert`e erişemeyecektir.
+Yukarıdaki kodda  eğer `yasKontrolu(yas)` `false` döndürür ise  `filmGoster` fonksiyonu `alert`e erişemeyecektir.
 
-````smart header="boş veya bir şey döndermeyen fonksiyon `undefined` dönderir"
-Eğer bir fonksiyon değer döndermiyor ise bu fonksiyon `undefined` dönderiyor ile aynı anlama gelir.
+````smart header="boş veya bir şey döndürmeyen fonksiyon `undefined` döndürür"
+Eğer bir fonksiyon değer döndürmüyor ise bu fonksiyon `undefined` döndürüyor ile aynı anlama gelir.
 
 
 ```js run
@@ -300,7 +300,7 @@ function biseyYapma() { /* boş */ }
 alert( biseyYapma() === undefined ); // true
 ```
 
-Boş dönderen `return`, `return undefined` ile aynıdır.
+Boş döndüren `return`, `return undefined` ile aynıdır.
 
 ```js run
 function biseyYapma() {
@@ -325,7 +325,7 @@ Bu çalışmaz, çünkü JavaScript `return` kelimesinden sonra `;` varsayara ve
 return*!*;*/!*
   (bazı + uzun + ifade + veya + baska + birsey  * f(a) + f(b))
 ```
-Bundan dolayı, tam olarak boş return olur. Geri döndereceğimiz değer ile return aynı satırda olmalıdır.
+Bundan dolayı, tam olarak boş return olur. Geri döndüreceğimiz değer ile return aynı satırda olmalıdır.
 
 ````
 
@@ -339,10 +339,10 @@ Genel itibari ile eylemi tanımlayan önek kullanmak iyi bir yöntemdir. Bu öne
 
 Fonksiyonlar şöyle başlayabilir.
 
-- `"get…"` -- değer dönderir,
+- `"get…"` -- değer döndürür,
 - `"calc…"` -- bir şeyler hesaplar,
 - `"create…"` -- bir şeyler yaratır,
-- `"check…"` -- bir şeyleri kontrol eder ve boolean dönderir.
+- `"check…"` -- bir şeyleri kontrol eder ve boolean döndürür.
 
 Böyle isimlere örnek:
 
@@ -350,9 +350,9 @@ Not: ingilizce de bu daha kolay önce eylemi yazıyorlar. Türkçe de fiil genel
 
 ```js no-beautify
 sendMessage(..)     // mesaj gönderir
-getAge(..)          // yaşı dönderir
-calcSum(..)         // toplamı hesaplar ve geri dönderir.
-createForm(..)      // form oluşturur ve genelde geri dönderir.
+getAge(..)          // yaşı döndürür
+calcSum(..)         // toplamı hesaplar ve geri döndürür.
+createForm(..)      // form oluşturur ve genelde geri döndürür.
 checkPermission(..) // izni kontor eder. true/false
 ```
 Önek ile fonksiyonlar bir anlamda ipucu verir ve ne tür değerler dönmesi gerektiğini anlatır.
@@ -364,7 +364,7 @@ Bir fonksiyon sadece isminin tanımladığı işi yapmalı.
 
 Bu kurallar şu şekilde bozulabilir:
 
-- `getAge` -- Eğer bu fonksiyon içeride `alert` ile yaş gösteriyor ise yanlış olur. Bu fonksiyonun sadece yaşı alıp döndermesi gerekmekte.
+- `getAge` -- Eğer bu fonksiyon içeride `alert` ile yaş gösteriyor ise yanlış olur. Bu fonksiyonun sadece yaşı alıp döndürmesi gerekmekte.
 - `createForm` -- Eğer dökümanı değiştiriyorsa veya forma bir şey ekliyorsa yanlış olur. ( Sadece formu yaratmalı ve geri dönmelidir )
 - `checkPermission` -- Eğer `izin verildi/reddedildi` gibi mesajları bu fonksiyon gösterirse yanlış olur. Sadece kontrol etmeli ve geri dönmelidir.
 
@@ -436,11 +436,11 @@ function fonksiyon ismi(parametreler, virgül , ile, ayrilirlar) {
 
 - Fonksiyona paslanan parametreler yerel değişken olarak fonksiyon içerisinde kopyalanırlar.
 - Fonksiyon dışarıdaki değişkene erişebilir. Fakat içeride yaratılmış bir değişken dışarıda kullanılamaz.
-- Fonksiyon değer dönderebilir. Eğer döndermezse `undefined`olarak tanımlanır.
+- Fonksiyon değer döndürebilir. Eğer döndürmezse `undefined`olarak tanımlanır.
 
 Kodun daha anlaşılır ve okunabilir olması için, fonksiyonlar içerisinde yerel değişken kullanılması önerilir. Dış değişkenler kullanılması önerilmez.
 
-Eğer fonksiyon parametre ile değer alır ve bu değer üzerinde çalışıp değer geri dönderirse anlaşılırlığı artar. Fakat eğer fonksiyon hiçbir parametre almadan sadece dışarıdaki değişkenleri değiştiriyor ise kodun anlaşılırlığı büyük ölçüde azalır.
+Eğer fonksiyon parametre ile değer alır ve bu değer üzerinde çalışıp değer geri döndürürse anlaşılırlığı artar. Fakat eğer fonksiyon hiçbir parametre almadan sadece dışarıdaki değişkenleri değiştiriyor ise kodun anlaşılırlığı büyük ölçüde azalır.
 
 Fonksiyon isimlendirme:
 

--- a/1-js/02-first-steps/14-function-basics/article.md
+++ b/1-js/02-first-steps/14-function-basics/article.md
@@ -319,7 +319,7 @@ Uzun `return` ifadelerinde, yeni bir satırda yazmak size kullanışlı gelebili
 return
  (bazı + uzun + ifade + veya + baska + birsey  * f(a) + f(b))
 ```
-Bu çalışmaz, çünkü JavaScript `return` kelimesinden sonra `;` varsayara ve `undefined` döner. Bu aşağoıdaki ifade ile aynıdır:
+Bu çalışmaz, çünkü JavaScript `return` kelimesinden sonra `;` varsayar ve `undefined` döner. Bu aşağıdaki ifade ile aynıdır:
 
 ```js
 return*!*;*/!*
@@ -331,9 +331,9 @@ Bundan dolayı, tam olarak boş return olur. Geri döndüreceğimiz değer ile r
 
 ## Fonksiyonu isimlendirme [#fonksiyon-isimlendirme]
 
-Fonksiyonlar eylemdir. Bundan dolayı isimleri yüklem olmalıdır. Net olmalı ve fonksiyonun ne işe yaradığını ifade edebilmelidir. Böylece kim ki kodu okur, ne yazıldığınına dair bir fikri olur.
+Fonksiyonlar eylemdir. Bundan dolayı isimleri yüklem olmalıdır. Net olmalı ve fonksiyonun ne işe yaradığını ifade edebilmelidir. Böylece kim ki kodu okur, ne yazıldığına dair bir fikri olur.
 
-Genel itibari ile eylemi tanımlayan önek kullanmak iyi bir yöntemdir. Bu önekler ile ilgili birlikte kod yazdığınız kişiler ile uyum içerisinde olmalısınız.
+Genel itibari ile eylemi tanımlayan ön ek kullanmak iyi bir yöntemdir. Bu ön ekler ile ilgili birlikte kod yazdığınız kişiler ile uyum içerisinde olmalısınız.
 
 Örneğin `"show"` fonksiyonu her zaman bir şeyleri `gösterir`.
 
@@ -346,7 +346,7 @@ Fonksiyonlar şöyle başlayabilir.
 
 Böyle isimlere örnek:
 
-Not: ingilizce de bu daha kolay önce eylemi yazıyorlar. Türkçe de fiil genelde sonda olduğundan dolayı sıkıntı yaşanmaktadır. Fonksiyonlarınızı adlandırırken ingilizce adlandırırsanız okunması daha kolay olacaktır.
+Not: İngilizce'de bu daha kolay önce eylemi yazıyorlar. Türkçe'de fiil genelde sonda olduğundan dolayı sıkıntı yaşanmaktadır. Fonksiyonlarınızı adlandırırken İngilizce adlandırırsanız okunması daha kolay olacaktır.
 
 ```js no-beautify
 sendMessage(..)     // mesaj gönderir
@@ -355,7 +355,7 @@ calcSum(..)         // toplamı hesaplar ve geri döndürür.
 createForm(..)      // form oluşturur ve genelde geri döndürür.
 checkPermission(..) // izni kontor eder. true/false
 ```
-Önek ile fonksiyonlar bir anlamda ipucu verir ve ne tür değerler dönmesi gerektiğini anlatır.
+Ön ek ile fonksiyonlar bir anlamda ipucu verir ve ne tür değerler dönmesi gerektiğini anlatır.
 
 ```smart header="Bir fonksiyon -- bir eylem"
 Bir fonksiyon sadece isminin tanımladığı işi yapmalı.
@@ -368,7 +368,7 @@ Bu kurallar şu şekilde bozulabilir:
 - `createForm` -- Eğer dökümanı değiştiriyorsa veya forma bir şey ekliyorsa yanlış olur. ( Sadece formu yaratmalı ve geri dönmelidir )
 - `checkPermission` -- Eğer `izin verildi/reddedildi` gibi mesajları bu fonksiyon gösterirse yanlış olur. Sadece kontrol etmeli ve geri dönmelidir.
 
-Bu örnekler genel olarak öneklerin nasıl tahmin edilmesi gerektiğini gösterir. Bunların ne anlama geleceği siz ve takımınıza kalmıştır. Belki sizin kodunuz için farklı bir şekilde davranması gayet doğal olabilir. Fakat yine de öneklere ait bir anlamlandırmanız olmalıdır. Ön ek ne yapabilir ne yapamaz vs. Tüm aynı önekli fonksiyonlar sizin koyduğunuz kurala uymalı ve tüm takım bu kuralları biliyor olmalıdır.
+Bu örnekler genel olarak öneklerin nasıl tahmin edilmesi gerektiğini gösterir. Bunların ne anlama geleceği siz ve takımınıza kalmıştır. Belki sizin kodunuz için farklı bir şekilde davranması gayet doğal olabilir. Fakat yine de ön eklere ait bir anlamlandırmanız olmalıdır. Ön ek ne yapabilir ne yapamaz vs. Tüm aynı önekli fonksiyonlar sizin koyduğunuz kurala uymalı ve tüm takım bu kuralları biliyor olmalıdır.
 ```
 
 ```smart header="Aşırı derecede kısa fonksiyon isimleri"
@@ -449,4 +449,4 @@ Fonksiyon isimlendirme:
 - Bunlar için ön ek kullanabilirsiniz. Türkçe sondan eklemeli bir dil olduğundan dolayı fonksiyon ekleri sona gelmektedir. Örneğin `asalGoster`, bu tip kullanım aslında okunurluk açısından pekte iyi değil benim kanaatimce. Çünkü okurken önce ne yaptığını anlaşılmıyor. Fakat İngilizce örneğine bakarsanız `showPrime`, burada önce ne yaptığını söylüyor. Farzedin ki birçok fonksiyonunuz var ve okuduğunuzda önce ne iş yaptığını bilmek bunları filtrelemenizde size yardımcı olacaktır.
 - Örnek kaç tane ek , `create...` , `show...`, `get...`, `check...` vs.
 
-Fonksiyonlar kod yazarken kullanılan ana yapılardır. Artık temellerini anlaşıldığına göre kullanılmaya başlanabilir. Fakat sadece temellerinin gösterildiğini bilmekte fayda var. ileride defalaraca fonksiyonlar konusuna geri dönülecektir.
+Fonksiyonlar kod yazarken kullanılan ana yapılardır. Artık temellerini anlaşıldığına göre kullanılmaya başlanabilir. Fakat sadece temellerinin gösterildiğini bilmekte fayda var. İleride defalarca fonksiyonlar konusuna geri dönülecektir.

--- a/1-js/02-first-steps/15-function-expressions/article.md
+++ b/1-js/02-first-steps/15-function-expressions/article.md
@@ -65,11 +65,11 @@ Detayına bakılacak olursa:
 1.`(1)` fonksiyon tanımlanır ve `selamVer` değişkenine atanır.
 2. `(2)` bunu `func` değişkenine kopyalar.
 
-Tekrardan hatırlatmak gerekirse: `selamVer` etrafında parantez bulunmamaktadır. Eğer `func = selamVer()` şeklinde parantez ile yazılacak olsaydı, 
+Tekrardan hatırlatmak gerekirse: `selamVer` etrafında parantez bulunmamaktadır. Eğer `func = selamVer()` şeklinde parantez ile yazılacak olsaydı,
 func değişkenine atanan değer `selamVer` fonksiyonunun kendisi değil, bu fonksiyonun çıktısı olurdu.
 
 3. Fonksiyon bundan sonra `selamVer()` ve `func()` şeklinde çağırılabilir.
- 
+
 Ayrıca ilk satır için *fonksiyon ifadesi* de kullanılabilirdi:
 
 ```js
@@ -99,7 +99,7 @@ let selamVer = function() {
 
 Cevap basit:
 - Kod bloklarının sonunda `;` e gerek yoktur. Örneğin `if{ ...}`, `for{ ... }`, `for { }`, `function f{}` vs.
-- Fonksiyon ifadesi bir ifade içinde kullanıldığından `let selamVer = ....;` bir değerdir. Kod bloğu değildir. Cümle sonlarında değer ne olursa olsun `;` kullanılması önerilir. Bundan dolayı `;` *fonksiyon ifadesi* ile alaklı değildir. Sadece tanımlamanın sonunu göstermek içindir. Tıpkı diğer tanımlamalarda olduğu gibi.
+- Fonksiyon ifadesi bir ifade içinde kullanıldığından `let selamVer = ....;` bir değerdir. Kod bloğu değildir. Cümle sonlarında değer ne olursa olsun `;` kullanılması önerilir. Bundan dolayı `;` *fonksiyon ifadesi* ile alakalı değildir. Sadece tanımlamanın sonunu göstermek içindir. Tıpkı diğer tanımlamalarda olduğu gibi.
 ````
 
 ## Geriçağrım Fonksiyonları ( Callback functions )
@@ -139,7 +139,7 @@ function iptalGoster() {
 sor("Kabul ediyor musunuz?", tamamGoster, iptalGoster);
 ```
 
-Daha kısa yolunu yazmadan önce söylemek gerekir ki bu tür fonksiyonlar oldukça sıkça kullanılmaktadır. Gerçek hayattaki örnekleri ile yukarıdaki arasında fark ise gerçek hayatta basit bir `confirm` yerine daha karmaşık olaylar için kullanılıyor olmalarıdır. 
+Daha kısa yolunu yazmadan önce söylemek gerekir ki bu tür fonksiyonlar oldukça sıkça kullanılmaktadır. Gerçek hayattaki örnekleri ile yukarıdaki arasında fark ise gerçek hayatta basit bir `confirm` yerine daha karmaşık olaylar için kullanılıyor olmalarıdır.
 
 **`sor` fonksiyonunun argümanları *callbacks* veya *geri çağrım fonksiyonları* olarak adlandırılırlar.
 
@@ -203,7 +203,7 @@ Yazım: Kodda neyin ne olduğunu görme.
 
 Daha ince bir değişiklik ise fonksiyonun JavaScript motorunda ne zaman yaratılacağıdır.
 
-**Fonksiyon ifadesi kod çalışırken fonksiyona geldikten sonra kullılır**
+**Fonksiyon ifadesi kod çalışırken fonksiyona geldikten sonra kullanılır**
 
 Çalışma atamanın sağ tarafına geçince `let sum = function...`, bu noktadan sonra fonksiyon artık yaratıldı. Bundan böyle çağırılabilir veya başka bir değişkene atanabilir.
 
@@ -288,9 +288,9 @@ if (yas < 18) {
   merhaba();               // \   (çalışır)
 */!*
                            //  |
-  function merhaba() {     //  |  
+  function merhaba() {     //  |
     alert("Merhaba!");     //  |  Fonksiyon tanımı bu blok içirisinde her yerden çağırılabilir.
-  }                        //  |  
+  }                        //  |
                            //  |
 *!*
   merhaba();               // /   (çalışır)
@@ -370,7 +370,7 @@ Fakat eğer Fonksiyon Tanımı işimize yaramaz ise(yukarıda örneğin Fonksiyo
 - Fonksiyon tanımları kod çalıştırmadan önce işlenir. Böylece kodun her yerinden ulaşılabilir olurlar.
 - Fonksiyon tanımları ise kod çalışırken bu tanıma erişirse çalışır.
 
-Çoğu zaman Fonksiyon Tanımı metodu tercih edilmelidir. Çünkü bu şekilde fonksiyon tanımlanmadan önce fonksiyon çağrısı yapmak mümkündür. Bu kodun daha düzenli tutulmasında yarcımdı olur. Ayrıca daha okunabilirdir.
+Çoğu zaman Fonksiyon Tanımı metodu tercih edilmelidir. Çünkü bu şekilde fonksiyon tanımlanmadan önce fonksiyon çağrısı yapmak mümkündür. Bu kodun daha düzenli tutulmasında yardımcı olur. Ayrıca daha okunabilirdir.
 
 Fonksiyon ifadesi sadece Fonksiyon Tanımı yetersiz kalırsa kullanılmalıdır. Bu örnek daha önce yukarıda yapılmıştı.
 

--- a/1-js/02-first-steps/16-arrow-functions-basics/article.md
+++ b/1-js/02-first-steps/16-arrow-functions-basics/article.md
@@ -63,7 +63,7 @@ let merhaba = (yas < 18) ?
   () => alert('Merhaba') :
   () => alert("Merhabalar!");
 
-merhaba(); 
+merhaba();
 ```
 
 Ok fonksiyonları ilk yazılmaya başlandığında göze yabancı gelebilir. Fakat zamanla göz bu yapıya alışacak ve hemen ayak uyduracaktır.
@@ -100,5 +100,5 @@ alert( toplam(1, 2) ); // 3
 
 Ok Fonksiyonları tek satır için kullanışlıdır. İki türlüsü vardır:
 
-1. Süslü parantez olmadan: Fonksiyon sağ taraftaki ifadeyi çalıştırır ve sonucu dönderir. Tek satırda biten işlemler için kullanılmalıdır.
+1. Süslü parantez olmadan: Fonksiyon sağ taraftaki ifadeyi çalıştırır ve sonucu döndürür. Tek satırda biten işlemler için kullanılmalıdır.
 2. Süslü parantez ile `(...args) => { gövde }` -- süslü parantez bizim birden fazla satır yazmamızı sağlar.  Fakat gövde içerisinde `return` kullanılması gerekmektedir.

--- a/1-js/02-first-steps/17-javascript-specials/article.md
+++ b/1-js/02-first-steps/17-javascript-specials/article.md
@@ -68,7 +68,7 @@ Dahası için: <info:strict-mode>.
 Değişkenler isimlendirilirken aşağıdakileri içerebilir:
 - Harf ve sayıları içerebilir fakat ilk karakter sayı olamaz.
 - `$` ve `_` gibi karakterler diğer karakterle aynı niteliktedir ve her yerde kullanılabilir.
-- Latin olmayan yani Arapça, Japonca, Çince gibi diller de kullanılabilir fakat genelde kullanılmaz. 
+- Latin olmayan yani Arapça, Japonca, Çince gibi diller de kullanılabilir fakat genelde kullanılmaz.
 
 Değişkenler dinamik yazıma sahiptir ve her şeyi tutabilirler:
 
@@ -86,7 +86,7 @@ x = "Ahmet";
 - `undefined` -- sadece `undefined` değerine sahiptir. Bu da "değer atanmamış" demektir,
 - `object` ve `symbol` -- karmaşık veri yapıları için ve tek tanıtıcı(unique identifier) için kullanılabilir. Bu konular henüz anlatılmadı.
 
-`typeof` operatörü değerin tipini dönderir, fakat şu hallerde hata verir:
+`typeof` operatörü değerin tipini döndürür, fakat şu hallerde hata verir:
 
 ```js
 typeof null == "object" // hata verir
@@ -100,15 +100,15 @@ Dahası için: <info:variables> ve <info:types> konularına bakabilirsiniz.
 Şu anda tarayıcıyı çalışma ortamı olarak kullandığınızdan dolayı, bazı basit arayüz fonksiyonlarını bilmekte fayda var:
 
 [`prompt(soru[, varsayılan])`](mdn:api/Window/prompt)
-: `soru` sor ve kullanıcının girdiği değeri dönder. Eğer kullanıcı "iptal" tuşuna bakarsa `null` dönder.
+: `soru` sor ve kullanıcının girdiği değeri döndür. Eğer kullanıcı "iptal" tuşuna bakarsa `null` döndür.
 
 [`confirm(soru)`](mdn:api/Window/confirm)
-: `soru` sor ve "Tamam" mı yoksa "İptal" mi diye seçenekler sun. Sonuçta seçilene göre  `true/false` dönder.
+: `soru` sor ve "Tamam" mı yoksa "İptal" mi diye seçenekler sun. Sonuçta seçilene göre  `true/false` döndür.
 
 [`alert(mesaj)`](mdn:api/Window/alert)
 : Mesajın çıktısını ekrana uyarı olarak ver.
 
-tüm bo fonksiyonlar *modal* dır. Tekrara hatırlatmak gerekirse modal kullanıcının etkileşimi olana kadar kodu durdururlar. Yani kullanıcıdan cevabı beklerler.
+Tüm bu fonksiyonlar *modal* dır. Tekrar hatırlatmak gerekirse modallar kullanıcının etkileşimi olana kadar kodu durdururlar. Yani kullanıcıdan cevabı beklerler.
 
 Örneğin:
 
@@ -143,7 +143,7 @@ Bit seviyesi işlemler
 : Bit seviye operatörleri şu şekilde kullanılabilir: [docs](mdn:/JavaScript/Reference/Operators/Bitwise_Operators)
 
 Üçlü operatör
-: Üç tane paremetreden oluşur: `koşul ? sonucA : sonucB`. Eğer `koşul` doğru ise `sonucA` döndürür, yanlış ise `sonucB` 
+: Üç tane paremetreden oluşur: `koşul ? sonucA : sonucB`. Eğer `koşul` doğru ise `sonucA` döndürür, yanlış ise `sonucB`
 
 Mantıksal operatörler:
 : Mantıksal VE `&&`, VEYA `||` operatörleri ile bu işlemler yapılabilir.
@@ -187,7 +187,7 @@ Geri kalan operatörleri daha derin bir biçimde <info:operators>, <info:compari
 - `for(let...)` içinde tanımlanan değişkenler sadece döngü içerisinden erişilebilirdir. Fakat `let`i pas geçip var olan değişkeni kullanmak da mümkündür.
 - Direktifler `break/continue` döngüden çıkılmasını sağlar. `label` kullanarak iç içe döngüde `break/continue` nereye dallanacağını belirleyebilirsiniz.
 
-Detaylaına <info:while-for> bölümünden erişebilirsiniz.
+Detaylarına <info:while-for> bölümünden erişebilirsiniz.
 
 İlerleyen bölümlerde döngülerin nasıl objelerle başa çıktığı üzerinde durulacaktır.
 
@@ -245,7 +245,7 @@ Detaylı bilgi için: <info:switch>.
     // ifada sağ tarafta
     let toplam = (a, b) => a + b;
 
-    // Çoklu satır için {..} kullanılmalı ve `return` ile değerin dönderilmesi gerekmektedir:
+    // Çoklu satır için {..} kullanılmalı ve `return` ile değerin döndürülmesi gerekmektedir:
     let toplam = (a, b) => {
       // ...
       return a + b;
@@ -269,7 +269,7 @@ Detaylı bilgi için: <info:switch>.
 | Tüm kod bloğunda görünür | kodların çalışması kendisine ulaşırsa çalışır |
 |   - | isme sahip olabilir, sadece fonksiyon içerisinde çalışır |
 
-Dahası için: <info:function-basics>, <info:function-expressions-arrows>. 
+Dahası için: <info:function-basics>, <info:function-expressions-arrows>.
 
 ## Dahası var
 

--- a/1-js/03-code-quality/01-debugging-chrome/article.md
+++ b/1-js/03-code-quality/01-debugging-chrome/article.md
@@ -6,7 +6,7 @@ Daha karmaşık kodlara geçmeden, hata ayıklama hakkında konuşmamız gerekme
 
 Geliştirici özellikleri en iyi olan tarayıcı Chrome olduğundan bu tarayıcı ile çalışacağız.
 
-## "Kaynak" paneli 
+## "Kaynak" paneli
 
 Şu anda sizin kullandığınız Chrome biraz farklı olabilir. Fakat bu panel kesinlikle orada biryerde olmalı
 
@@ -25,9 +25,9 @@ Bu panelde `hello.js` i seçtiğinizde aşağıdaki gibi bir ekran görmeniz ger
 ![](chrome-tabs.svg)
 
 Bu bölüm üçe ayrılmıştır:
-1. **Dosya Gezgini**: Html, javascript, css ve diğer dosyalar görseller de dahil olmak üzere açılan sayfaya iat olan kaynakları gösterir. Chrome eklentileri de burada yer alabilir.
+1. **Dosya Gezgini**: Html, javascript, css ve diğer dosyalar görseller de dahil olmak üzere açılan sayfaya ait olan kaynakları gösterir. Chrome eklentileri de burada yer alabilir.
 2. **Kod Editörü** burası ise kaynak kodu gösterir.
-3. **Bilgi ve kontrol bölgesi** burada ise hata ayıklama yapılır. 
+3. **Bilgi ve kontrol bölgesi** burada ise hata ayıklama yapılır.
 
 Şimdi geliştirici araçlarının sol köşesinde bulunan <span class="devtools" style="background-position:-172px -122px"></span> açma kapama bölümünü kullanarak kendinize biraz yer açabilirsiniz.
 
@@ -97,10 +97,10 @@ Lütfen bilgilerin görüneceği dropdownları sağ panelden açınız. Bu böl�
 
 1. **`Watch` -- herhangi bir ifadenin o anki değerini gösterir.**
     `+` işaretine basarak ifade girebilirsiniz. Bu ifadenin değerini kod ayıklayıcı her halükarda gösterir. Kod çalışırken bu değerleri her adımda kontrol eder ve sonucunu yazar.
-    
+
 2. **`Call Stack` -- İç içe çağrı zincirlerini gösterir.**
 
-    Şu anda hata ayıklayıcı `merhaba()` fonksiyonunun içindedir ve `index.html` tarafından çağırılmıştır. Eğer  yığın(stack) bölgesine dikkat ederseniz fonksiyona girdiğinde nereden çağırıldığını gösterir. ( her hangi bir fonksiyondan çağırılmadığından dolayı "anonymous" olarak göreceksiniz)
+    Şu anda hata ayıklayıcı `merhaba()` fonksiyonunun içindedir ve `index.html` tarafından çağırılmıştır. Eğer  yığın(stack) bölgesine dikkat ederseniz fonksiyona girdiğinde nereden çağırıldığını gösterir. ( herhangi bir fonksiyondan çağırılmadığından dolayı "anonymous" olarak göreceksiniz)
 
     Eğer yığın maddesine tıklayacak olursanız hangi fonksiyondan çağırıldığını görebilirsiniz.
 3. **`Scope` -- kesme anında var olan değişkenlerin değerlerini gösterir**
@@ -134,7 +134,7 @@ Sağ panelin üstünde sadece bu işe has butonlar bulunmaktadır.
 : Bir öncekinin aynısı, bir adım gider fakat bu defa eğer bir fonksiyon varsa onun "içine girer"(step into).
 
 <span class="devtools" style="background-position:-104px -76px"></span> -- içinde bulunulan fonksiyonun sonuna kadar devam et, `key:Shift+F11`.
-: Çalışma içinde bulunan fonksiyonun sonuna gelir ve orada durur.Yanlışlıkla iç içe çağrının içine girilirse çıkmak için kullanışlı bir özelliktir.<span class="devtools" style="background-position:-72px -76px"></span>, 
+: Çalışma içinde bulunan fonksiyonun sonuna gelir ve orada durur.Yanlışlıkla iç içe çağrının içine girilirse çıkmak için kullanışlı bir özelliktir.<span class="devtools" style="background-position:-72px -76px"></span>,
 
 <span class="devtools" style="background-position:-7px -28px"></span> -- Tüm kesme noktalarını etkinleştirme/devre dışı bırakma.
 
@@ -166,10 +166,10 @@ Bahsettiğimiz gibi çalışan kodu durdurmanın üç farklı yönü vardır. Bu
 2. `debugger` kelimesi ile durdurma
 3. Eğer hata olduğunda aç/kapa butonu aktifse çalışmada hata olduğunda  <span class="devtools" style="background-position:-264px -4px"></span> durdurma
 
-Bunların sonucunda çalışmada ne gibi hatalar olduğunu görebilirsiniz. 
+Bunların sonucunda çalışmada ne gibi hatalar olduğunu görebilirsiniz.
 
 Bunlara ek olarak <https://developers.google.com/web/tools/chrome-devtools> adresinden daha geniş ve yeni bilgilere ulaşabilirsiniz.
 
 Bu bölümdeki bilgiler sizin hata ayıklama işlemine başlamanızda yardımcı olacaktır. Fakat tarayıcı ile alakalı çok fazla işlem yapıyorsanız bu durumda geliştirici  derinlemesine incelemeniz gerekmektedir.
 
-Tabi bunun yanında deneme yanılma yöntemiy ile de geliştirici araçlarının özelliklerini keşfedebilirsiniz. Unutmayın sağ tıklayarak farklı bölgelerde farklı fonksiyonları görebilirsiniz.
+Tabi bunun yanında deneme yanılma yöntemi ile de geliştirici araçlarının özelliklerini keşfedebilirsiniz. Unutmayın sağ tıklayarak farklı bölgelerde farklı fonksiyonları görebilirsiniz.

--- a/1-js/03-code-quality/02-coding-style/article.md
+++ b/1-js/03-code-quality/02-coding-style/article.md
@@ -9,7 +9,7 @@ Buna yardımcı olan bir şey de iyi kodlama stilidir.
 
 ## Yazım
 
-Kodlar için yazımış bir kopya kağıdı(detayları aşağıda):
+Kodlar için yazılmış bir kopya kağıdı(detayları aşağıda):
 
 ![](code-style.svg)
 <!--
@@ -38,7 +38,7 @@ if (n < 0) {
 -->
 Şimdi bu kurallar ve nedenleri hakkında konuşabiliriz.
 
-Buradaki hiçbir şey kanun değildir. Hepsi sizin zevgine kalmıştır ve değişebilir. Buradaki kodlama kuralları dogmalara dayanmaz.
+Buradaki hiçbir şey kanun değildir. Hepsi sizin zevkinize kalmıştır ve değişebilir. Buradaki kodlama kuralları dogmalara dayanmaz.
 
 ### Süslü Parantez
 
@@ -47,7 +47,7 @@ Buradaki hiçbir şey kanun değildir. Hepsi sizin zevgine kalmıştır ve deği
 
 ```js
 if (kosul) {
-  // şunu yap 
+  // şunu yap
   // ...bunu yap
   // ...sonra bunu yap
 }
@@ -91,7 +91,7 @@ Satır uzunluğu limitine takım seviyesinde karar verilir. Genelde 80-120 karak
 İki türlü satır başı standardı vardır.
 
 - **Yatay boşluklar:2(4) boşluk.**
-    
+
     Yatay boşluklar genelde 2 veya 4 veya "Tab" sembolünden oluşur. Bunlardan hangisinin seçilmesi gerektiği bir çeşit savaştır. Bugünlerde boşluk tuşu ile boşluk bırakmak daha fazla kullanılan yöntemdir.
 
     Boşluk tuşu ile satıra başlamanın "Tab" a göre üstünlü daha esnek ayarlanabilir olmasından dolayıdır.
@@ -100,7 +100,7 @@ Satır uzunluğu limitine takım seviyesinde karar verilir. Genelde 80-120 karak
 
     ```js no-beautify
     goster(parametreler,
-         hizalandı, // soldan 5 boşluk  
+         hizalandı, // soldan 5 boşluk
          ilki,
          sonra,
          digeri
@@ -125,7 +125,7 @@ Satır uzunluğu limitine takım seviyesinde karar verilir. Genelde 80-120 karak
     }
     ```
 
-    Eğer okunurluluğa etki edecekse yeni bir satır arası vermekten çekinmeyin. Kanıya göre 9 satıdan fazla kod varsa arada kesin bir satır arası olmalıdır.
+    Eğer okunurluluğa etki edecekse yeni bir satır arası vermekten çekinmeyin. Kanıya göre 9 satırdan fazla kod varsa arada kesin bir satır arası olmalıdır.
 
 ### Noktalı virgül
 
@@ -179,7 +179,7 @@ function ust(x, n) {
     }
 
     return sonuc;
-  }  
+  }
 }
 ```
 
@@ -202,11 +202,11 @@ function ust(x, n) {
 }
 ```
 
-... fakat ikincisi daha okunaklıdır, çünkü `n<0` koşulu ilk önce kontrol edildi ve buna göre aksiyon alındı sonrsında ana kod akışına devam edildi, ayrıca bir `else` yazmaya gerek kalmadı.
+... fakat ikincisi daha okunaklıdır, çünkü `n<0` koşulu ilk önce kontrol edildi ve buna göre aksiyon alındı sonrasında ana kod akışına devam edildi, ayrıca bir `else` yazmaya gerek kalmadı.
 
 ## Kodun altında fonksiyonlar
 
-Eğer bir kaç tane "helper"(yardımcı) fonksiyon yazıyorsanız bunları yerleştirmenin üç farklı yolu var.
+Eğer birkaç tane "helper"(yardımcı) fonksiyon yazıyorsanız bunları yerleştirmenin üç farklı yolu var.
 
 1. Kullanan kodun üstünde fonksiyonları tanımlamak:
 
@@ -258,7 +258,7 @@ Eğer bir kaç tane "helper"(yardımcı) fonksiyon yazıyorsanız bunları yerle
 
 ## Stil Klavuzu
 
-Stil klavuzları genel olarak "nasıl yazılmalı" sorusunun cevabını verir: Kaç satır bırakılmalıdırı, nerede yeni satıra geçilmelidir vs. çok küçük küçük şeyler.
+Stil klavuzları genel olarak "nasıl yazılmalı" sorusunun cevabını verir: Kaç satır bırakılmalıdır, nerede yeni satıra geçilmelidir vs. çok küçük küçük şeyler.
 
 Genel olarak tüm takım üyeleri bu kurallara uyduğunda kod tek bir elden çıkmış gibi görünür. Kimin yazdığı önemini yitirir.
 
@@ -279,7 +279,7 @@ Kod stilinizi otomatik olarak denetleyen araçlar bulunmaktadır. Bunlara "düze
 
 Bunların en önemli özelliği stili kontrol etmesinin yanında yazımdaki hataları, fonksiyon isimlerindeki problemleri bulur.
 
-Bundan dolayı bir tanesini kullanmanız öneririli. Sadece kelime hatalarını düzeltmeniz için bile olsa kullanmanız iyidir.
+Bundan dolayı bir tanesini kullanmanız öneririlir. Sadece kelime hatalarını düzeltmeniz için bile olsa kullanmanız iyidir.
 
 En çok bilinen araçlar:
 
@@ -287,7 +287,7 @@ En çok bilinen araçlar:
 - [JSHint](http://www.jshint.com/) -- JSLintden daha fazla özelliğe sahip.
 - [ESLint](http://eslint.org/) -- en yenilerinden.
 
-Hepside işinizi görür. Yazar  [ESLint](http://eslint.org/) kullanmatadır.
+Hepside işinizi görür. Yazar  [ESLint](http://eslint.org/) kullanmaktadır.
 
 Çoğu otomatik düzenleyici editör ile entegre çalışır. Sadece plugin'i aktif edin, kod stilini ayarlayın yeterli.
 
@@ -317,7 +317,7 @@ Buradaki `"extends"` normalde `eslint:recommended` i kullanacağımız fakat bun
 
 Bunun ardından editörünüzde ESLint eklentisini aktif edin. Çoğu editörde bu eklenti bulunmaktadır.
 
-Bunun yanında bu stilleri internetten indirip kullanmakta mümkündür. Bunun için 
+Bunun yanında bu stilleri internetten indirip kullanmakta mümkündür. Bunun için
 <http://eslint.org/docs/user-guide/getting-started> adresine bakabilirsiniz.
 
 Bunun yanında otomatik düzenleyici kullanmanın yan etkileri de vardır. Kod düzenleyiciler eğer tanımlanmamış bir değişken kullanılmışsa, bunu anlar ve vurgular. Fakat çoğu defa bunun nedeni yanlış yazımdır. Tabi bunu farkederseniz düzeltmesi de hemen yapılabilir.
@@ -329,7 +329,7 @@ Ayrıca bazı IDEler bu otomatik düzenleyicileri kendileri doğrudan entegre ed
 
 ## Özet
 
-Bu bölümdeki tüm yazım kurallar ve stil klavuzlarının amacı okunabilrliği artırmaktır. Bundan dolayı tamamı tartışılabilir.
+Bu bölümdeki tüm yazım kurallar ve stil klavuzlarının amacı okunabilirliği artırmaktır. Bundan dolayı tamamı tartışılabilir.
 
 "Nasıl daha iyi yazarız?" sorusu hakkında düşündüğümüzde, kriter "Nasıl daha iyi okunur kod yazabilir, nasıl yazarken hatalardan kaçabiliriz?" sorularını aklımızda tutmamız gereklidir. Buna göre stil seçip hangisinin daha iyi olduğuna karar verebiliriz.
 

--- a/1-js/03-code-quality/03-comments/article.md
+++ b/1-js/03-code-quality/03-comments/article.md
@@ -3,7 +3,7 @@
 <info:structure> bölümünden de bildiğiniz üzre, yorumlar tek satır `//` olabileceği gibi birden çok satır da olabilir `/* .. */`.
 Genelde  yorum satırları kodun nasıl ve niçin çalıştığını anlatmak için kullanılır.
 
-İlk görüşte yorum yapmanın gereklilik olduğu aşikardır. Fakat programlama yeni başlayanlayanlar bunu ilk önce genelde yanlış anlamaktadırlar.
+İlk görüşte yorum yapmanın gereklilik olduğu aşikardır. Fakat programlama yeni başlayanlar bunu ilk önce genelde yanlış anlamaktadırlar.
 
 ## Kötü Yorum
 
@@ -51,7 +51,7 @@ function asalSayilariGoster(n) {
   for (let i = 2; i < n; i++) {
     *!*if (!asalMi(i)) continue;*/!*
 
-    alert(i);  
+    alert(i);
   }
 }
 
@@ -109,7 +109,7 @@ function addJuice(kap) {
 ```
 Tekrardan söylemek gerekirse nelerin olup bittiğini yorum değil, fonksiyonun kendisi söylemeli.Ayrıca kod yapısı fonksiyonlar şeklinde ayrık olduğunda daha düzgün olur. Her fonksiyonun ne argüman aldığı ne geri döndürdüğü bellidir.
 
-Gerçekte neyin olup bittiğini söyleyen yorumu tamamen çıkarmak olanaksızdır. Bazen karmaşık algorimalara olabilir. Bazen akıllıca yapılmış kısayollar olabilir. Fakat genel olarak kod basit ve kendi kendini açıklayıcı olmalı.
+Gerçekte neyin olup bittiğini söyleyen yorumu tamamen çıkarmak olanaksızdır. Bazen karmaşık algorimalar olabilir. Bazen akıllıca yapılmış kısayollar olabilir. Fakat genel olarak kod basit ve kendi kendini açıklayıcı olmalı.
 
 
 ## İyi yorum
@@ -117,10 +117,10 @@ Gerçekte neyin olup bittiğini söyleyen yorumu tamamen çıkarmak olanaksızd�
 Peki, fonksiyonun ne yaptığını anlatan yorumlar kötü ise, hangi yorumlar iyi?
 
 Mimariyi tanımla
-: Üst seviyede bileşenlere genel bakış, nasıl birbirleriyle iletişim kurdukları, farklı durumlarda akışın nasıl değişeceği gibi konular anlatılmalıdır. Kusaca kuş bakışı kodun ne yaptığını anlatmalısınız. Bununla ilgili şema diline [UML](https://tr.wikipedia.org/wiki/UML) bakabilirsiniz. Kesinlikle üstünde çalışılmaya değer.
+: Üst seviyede bileşenlere genel bakış, nasıl birbirleriyle iletişim kurdukları, farklı durumlarda akışın nasıl değişeceği gibi konular anlatılmalıdır. Kısaca kuş bakışı kodun ne yaptığını anlatmalısınız. Bununla ilgili şema diline [UML](https://tr.wikipedia.org/wiki/UML) bakabilirsiniz. Kesinlikle üstünde çalışılmaya değer.
 
 Fonksiyon kullanımını dökümante etme
-: Fonksiyonu dökümante edebilmek için standart özel bir yazım vardır[JSDoc](http://tr.wikipedia.org/wiki/JSDoc). Fonksiyon: kullım, parametreler, dönen değer.
+: Fonksiyonu dökümante edebilmek için standart özel bir yazım vardır[JSDoc](http://tr.wikipedia.org/wiki/JSDoc). Fonksiyon: kullanım, parametreler, dönen değer.
 
     Örneğin:
     ```js
@@ -135,7 +135,7 @@ Fonksiyon kullanımını dökümante etme
       ...
     }
     ```
-    Bu yorumlar gize bu fonksiyonun amacının ne olduğunu koda bakmadan anlatır.
+    Bu yorumlar bize bu fonksiyonun amacının ne olduğunu koda bakmadan anlatır.
 
     Bu arada [WebStorm](https://www.jetbrains.com/webstorm/) gibi editörler size JSDoc yazma konusunda yardımcı olur. Otomatik olarak kodu kontrol edebilir.
 

--- a/1-js/03-code-quality/04-ninja-code/article.md
+++ b/1-js/03-code-quality/04-ninja-code/article.md
@@ -61,7 +61,7 @@ Harika görselin belirli bir formu yoktur.
 ```
 
 Bir kelime seçerken soyut olmasına önem verin. Örneğin
-While choosing a name try to use the most abstract word. Like `obj`, `data`, `value`, `item`, `elem` vs. 
+Bir isim seçerken en soyut kelimeyi kullanmaya çalışın. `obj`, `data`, `value`, `item`, `elem` gibi.
 
 - **Kusursuz değişken ismi `data`** nerede isterseniz kullanın. Gerçekten de tüm değişkenler *data* tutmuyorlar zaten, değil mi?
 
@@ -192,7 +192,7 @@ Sonrasında dışta bulunan `kullanici` değişkenine bakacak ve `kullaniciBilgi
 
 Bazı fonksiyonlar hiçbir şey değiştirmiyormuş gibi görünür. Örneğin `hazirMi()`, `izinKontrol()`, `tagbul()` gibi. Hesaplamaları yapıp veriyi geri döndürdüğü ve bunun dışında bir değişiklik yapılmadığı tahmin edilsin. Diğer bir deyişle "yan etkisi" olmadığı.
 
-**En güzel kurnazlık bunlara kendi görevleri dışında "işe yarar" bir eylem yaptırın** 
+**En güzel kurnazlık bunlara kendi görevleri dışında "işe yarar" bir eylem yaptırın**
 
 İş arkadaşınızın yüzündeki şaşkınlığı düşünebiliyor musunuz? `hazirMi`,`kontrolEt`, `bul...` gibi fonksiyonlar bir şeyleri değiştiriyor. Gerçekten de sınırları zorlayan bir yöntem.
 


### PR DESCRIPTION
- Döndermek tabirinin doğrusu döndürmek, onları düzelttim.
- Ön ek ayrı yazılıyor, onu düzelttim.
- Genel olarak bazı typolar vardı onları düzelttim.
Diğer bölümlere de ayrı bakacağım, ellerinize sağlık:)